### PR TITLE
Se fixeo el manejo de Error de Teams, para que muestre el error exacto

### DIFF
--- a/src/components/teams-table/team/EditTeamDialog.tsx
+++ b/src/components/teams-table/team/EditTeamDialog.tsx
@@ -81,7 +81,7 @@ export default function EditTeamDialog({ data, onClose }: EditTeamDialogProps ) 
     mutationFn: async (values: z.infer<typeof formSchema>) => {
       const session = await getSession();
       const token = session?.user.access_token;
-      await updateTeam( values as any , token as string, data.id);
+      return await updateTeam(values as any, token as string, data.id);
     },
     onSuccess: () => {
       toast({
@@ -91,10 +91,10 @@ export default function EditTeamDialog({ data, onClose }: EditTeamDialogProps ) 
       queryClient.invalidateQueries({ queryKey: ['teams'] });
       onClose();
     },
-    onError: (error: unknown) => {
+    onError: (error: any) => {
       toast({
-        title: 'Oh no! Algo está mal',
-        description: (error as Error).message,
+        title: 'Error al editar equipo',
+        description: error.message,
         variant: 'destructive',
       });
     },

--- a/src/services/teamsService.ts
+++ b/src/services/teamsService.ts
@@ -2,6 +2,7 @@ import { Group } from './groupsService';
 import { Patient } from './patientService';
 import { post, get, patch, del } from './requestHandler';
 
+
 interface createTeam {
   teamName: string;
   groupId: string;
@@ -61,13 +62,23 @@ export const updateTeam = async (
   token: string,
   teamId: string
 ) => {
-  const response = await patch(`/teams/${teamId}`, data, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  return response.data;
+  try {
+    const response = await patch(`/teams/${teamId}`, data, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    return response.data;
+  } catch (error: any) {
+    // Capturamos el mensaje de error específico del backend
+    if (error.response?.data?.message) {
+      throw new Error(error.response.data.message);
+    } else if (error.message) {
+      throw new Error(error.message);
+    } else {
+      throw new Error('Error inesperado al actualizar el equipo');
+    }
+  }
 }
 
 export const deleteTeam = async (teamId: string, token: string) => {


### PR DESCRIPTION
# Mejora en el manejo de errores UI para Teams

## Cambios realizados
- Se mejoró el manejo y visualización de errores en el componente EditTeamDialog
- Se actualizó el servicio de teams para capturar y propagar mensajes de error del backend
- Se implementó mejor UX en la presentación de errores al usuario

## Detalles técnicos
- Se modificó teamsService para capturar correctamente los mensajes de error del backend
- Se mejoró el componente EditTeamDialog para mostrar mensajes de error específicos
- Se actualizó el manejo de errores en el mutation para mostrar mensajes descriptivos

## Testing
- Verificar que los mensajes de error del backend se muestran correctamente en el toast
- Confirmar que los errores son claros y descriptivos para el usuario
- Validar que el mensaje de error muestra el equipo al que pertenece el paciente cuando hay conflicto